### PR TITLE
Remove scrape annotations from pod

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0"
 description: Collect ALL UniFi Controller, Site, Device & Client Data - Export to InfluxDB or Prometheus
 name: unifi-poller
-version: 0.1.1
+version: 0.1.2
 icon: https://raw.githubusercontent.com/wiki/unifi-poller/unifi-poller/images/unifi-poller-logo.png
 home: https://github.com/unifi-poller/unifi-poller
 sources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -13,11 +13,6 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if not .Values.config.prometheus.disable }}
-        prometheus.io/path: /metrics
-        prometheus.io/port: "9130"
-        prometheus.io/scrape: "true"
-        {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "unifi-poller.name" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -14,9 +14,15 @@ spec:
     metadata:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- with .Values.pod.annotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "unifi-poller.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,10 @@ service:
   port: 9130
   annotations: {}
 
+pod:
+  annotations: {}
+  labels: {}
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Many prometheus implementations scrape pods and service endpoints. If both have the prometheus annotation, metrics will get duplicated because they show up as two separate scrape targets. This removes the annotation from the pods so that it'll scrape the service. You could do the opposite, but it seemed like that would duplicate metrics if you were running multiple replicas of the pods, so this seemed preferable.